### PR TITLE
Fix playing of next track in playlist

### DIFF
--- a/plexmusicplayer/intents/amazon_intents.py
+++ b/plexmusicplayer/intents/amazon_intents.py
@@ -28,7 +28,7 @@ def nearly_finished():
 @ask.on_playback_finished()
 def play_back_finished():
     if queue.whats_next:
-        queue.go_next()
+        return audio("").play(queue.go_next().stream_url)
 
 @ask.intent('AMAZON.NextIntent')
 def next_song():

--- a/plexmusicplayer/intents/plex_intents.py
+++ b/plexmusicplayer/intents/plex_intents.py
@@ -8,27 +8,27 @@ import plexmusicplayer.methods as methods
 
 @ask.intent('PlexPlayTrackIntent')
 def playTrack(track):
-    speech, playlist = methods.processQuery(track, MediaType.Track)
+    speech, playlist = methods.processTrackQuery(track, MediaType.Track)
+    return makeRespone(speech, playlist)
+
+@ask.intent('PlexPlayTrackByArtistIntent')
+def playTrackByArtist(track, artist):
+    speech, playlist = methods.processTrackByArtistQuery(track, artist, MediaType.Track)
     return makeRespone(speech, playlist)
 
 @ask.intent('PlexPlayAlbumIntent')
 def playAlbum(album):
-    speech, playlist = methods.processQuery(album, MediaType.Album)
-    return makeRespone(speech, playlist)
-
-@ask.intent('PlexPlayTrackByArtistIntent')
-def playTrack(track):
-    speech, playlist = methods.processQuery(track, MediaType.Track)
+    speech, playlist = methods.processAlbumQuery(album, MediaType.Album)
     return makeRespone(speech, playlist)
 
 @ask.intent('PlexPlayAlbumByArtistIntent')
-def playAlbum(album):
-    speech, playlist = methods.processQuery(album, MediaType.Album)
+def playAlbumByArtist(album, artist):
+    speech, playlist = methods.processAlbumByArtistQuery(album, artist, MediaType.Album)
     return makeRespone(speech, playlist)
 
 @ask.intent('PlexPlayArtistIntent')
 def playArtist(artist):
-    speech, playlist = methods.processQuery(artist, MediaType.Artist)
+    speech, playlist = methods.processArtistQuery(artist, MediaType.Artist)
     return makeRespone(speech, playlist)
 
 @ask.intent('PlexWhatSongIntent')

--- a/plexmusicplayer/utils.py
+++ b/plexmusicplayer/utils.py
@@ -63,7 +63,7 @@ class QueueManager(object):
         return self._counter.value
 
     def shuffle(self):
-        shuffle = [self._playlist[(self._counter.value+1):]]
+        shuffle = self._playlist[(self._counter.value+1):]
         random.shuffle(shuffle)
         self._playlist = self._playlist[:(self._counter.value+1)] + shuffle
 


### PR DESCRIPTION
A few fixes in here:

- currently when a track finishes the playlist pointer moves to the next track, but it doesn't play
- shuffle appends the shuffled tracks as an array, so it just gets seen as a single playlist entry
- search for a track/album by artist just returns the first match track/album without taking the artist name into account

With the last fix, I've allowed for a bit of leeway with the artist name. This might need adjusting to be more/less accurate depending how it fares, but the current value seemed to work quite well for me.