### PR TITLE
fixing intent utterance bug

### DIFF
--- a/speech_assets/intentSchema.txt
+++ b/speech_assets/intentSchema.txt
@@ -25,14 +25,14 @@
             "intent": "PlexPlayTrackIntent",
           	"slots": [{
               	"name": "track",
-              	"type": "AMAZON.MusicCreativeWorkType"
+              	"type": "AMAZON.MusicRecording"
             }]
         },
         {
             "intent": "PlexPlayTrackByArtistIntent",
             "slots": [{
                 "name": "track",
-                "type": "AMAZON.MusicCreativeWorkType"
+                "type": "AMAZON.MusicRecording"
             },{
                 "name": "artist",
                 "type": "AMAZON.MusicGroup"
@@ -73,14 +73,14 @@
             "intent": "PlexQueueTrackIntent",
             "slots": [{
                 "name": "track",
-                "type": "AMAZON.MusicCreativeWorkType"
+                "type": "AMAZON.MusicRecording"
             }]
         },
         {
             "intent": "PlexQueueTrackByArtistIntent",
             "slots": [{
                 "name": "track",
-                "type": "AMAZON.MusicCreativeWorkType"
+                "type": "AMAZON.MusicRecording"
             },{
                 "name": "artist",
                 "type": "AMAZON.MusicGroup"


### PR DESCRIPTION
fixing bug with intent schema where words defined in Amazon.CreativeWorkType (album, track, song, artist...) were being given special treatment and causing the intent utterance matching to misbehave.